### PR TITLE
Use Rust Secp256k1 implementation from RustCrypto project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,12 @@ jobs:
 
     - name: Build
       run: |
-        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-14/wasi-sdk_14.0_amd64.deb -o /tmp/wasi-sdk.deb
-        sudo dpkg -i /tmp/wasi-sdk.deb
         rustup target add wasm32-wasi
-        CC=/opt/wasi-sdk/bin/clang cargo build --release --target wasm32-wasi
+        cargo build --release --target wasm32-wasi
     - name: Optimize
       run: |
-        sudo apt-get update && sudo apt-get install binaryen wabt
-        wasm2wat target/wasm32-wasi/release/hdwallet.wasm | grep -v '^\s*(export "rustsecp256k1_' > target/wasm32-wasi/release/hdwallet.exp.wat
-        wat2wasm target/wasm32-wasi/release/hdwallet.exp.wat -o target/wasm32-wasi/release/hdwallet.exp.wasm
-        wasm-opt target/wasm32-wasi/release/hdwallet.exp.wasm -O4 -o target/wasm32-wasi/release/hdwallet.opt.wasm --strip-debug --strip-producers
+        sudo apt-get update && sudo apt-get install binaryen
+        wasm-opt target/wasm32-wasi/release/hdwallet.wasm -O4 -o target/wasm32-wasi/release/hdwallet.opt.wasm --strip-debug --strip-producers
 
     - name: Release
       id: create_release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: |
-        curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-14/wasi-sdk_14.0_amd64.deb -o /tmp/wasi-sdk.deb
-        sudo dpkg -i /tmp/wasi-sdk.deb
         rustup target add wasm32-wasi
-        CC=/opt/wasi-sdk/bin/clang cargo build --target wasm32-wasi
+        cargo build --target wasm32-wasi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,10 +26,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base64ct"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -39,12 +60,6 @@ checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "cc"
-version = "1.0.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -92,12 +107,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -111,14 +144,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "der"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -126,6 +217,16 @@ name = "ethnum"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b40347dcad92b4dfeb9765c41c48503416daddf6dba55b74614dc035a43ed2"
+
+[[package]]
+name = "ff"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "generic-array"
@@ -138,6 +239,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,20 +268,20 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdwallet"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
  "ethnum",
  "hex",
  "hex-literal",
- "hmac",
+ "hmac 0.12.1",
+ "k256",
  "maplit",
  "pbkdf2",
- "secp256k1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.2",
  "sha3",
  "unicode-normalization",
 ]
@@ -192,11 +315,21 @@ checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -214,6 +347,19 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "k256"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sec1",
+ "sha2 0.9.9",
+]
 
 [[package]]
 name = "keccak"
@@ -240,6 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,7 +403,18 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der",
+ "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -297,27 +460,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac 0.11.0",
+ "zeroize",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
-name = "secp256k1"
-version = "0.22.1"
+name = "sec1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b5b9d7322572e1f3aeed208668ce87789b3645dbb73082c5ce99a004103a35"
-dependencies = [
- "cc",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -353,13 +531,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -368,8 +559,28 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
- "digest",
+ "digest 0.10.3",
  "keccak",
+]
+
+[[package]]
+name = "signature"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+dependencies = [
+ "digest 0.9.0",
+ "rand_core",
+]
+
+[[package]]
+name = "spki"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -453,6 +664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,3 +699,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdwallet"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>"]
 edition = "2021"
 description = "Ethereum hierarchical deterministic wallet implementation"
@@ -15,8 +15,8 @@ clap = { version = "3", features = ["derive", "env"] }
 ethnum = "1"
 hex = "0.4"
 hmac = { version = "0.12", features = ["std"] }
+k256 = "0.10"
 pbkdf2 = { version = "0.11", default-features = false }
-secp256k1 = { version = "0.22", features = ["recovery"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src/account/prehashed.rs
+++ b/src/account/prehashed.rs
@@ -1,0 +1,61 @@
+//! The `k256` crate only supports signing messages by passing message bytes and
+//! specifying a hasher, or specifying an already partially updated hasher.
+//!
+//! This module provides a `Digest` implementation that can be used as an
+//! allowing `k256` signing to be done on a prehashed messsage.
+
+use k256::ecdsa::digest::{
+    consts::U32, generic_array::GenericArray, BlockInput, FixedOutput, Reset, Update,
+};
+use sha2::{digest::core_api::BlockSizeUser, Digest as _, Sha256};
+use std::mem;
+
+/// A pre-hashed meessage.
+#[derive(Clone)]
+pub enum Prehashed {
+    /// The pre-hashed message to use for signing.
+    Message([u8; 32]),
+    /// The hasher used for rfc-6979 nonce generation for deterministic ECDSA
+    /// signature computation.
+    Rfc6979(Sha256),
+}
+
+impl Default for Prehashed {
+    fn default() -> Self {
+        Self::Rfc6979(Sha256::default())
+    }
+}
+
+impl BlockInput for Prehashed {
+    type BlockSize = <Sha256 as BlockSizeUser>::BlockSize;
+}
+
+impl FixedOutput for Prehashed {
+    type OutputSize = U32;
+
+    fn finalize_into(self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        match self {
+            Self::Message(message) => *out = message.into(),
+            Self::Rfc6979(hasher) => hasher.finalize_into(out),
+        }
+    }
+
+    fn finalize_into_reset(&mut self, out: &mut GenericArray<u8, Self::OutputSize>) {
+        mem::take(self).finalize_into(out)
+    }
+}
+
+impl Reset for Prehashed {
+    fn reset(&mut self) {
+        *self = Default::default();
+    }
+}
+
+impl Update for Prehashed {
+    fn update(&mut self, data: impl AsRef<[u8]>) {
+        match self {
+            Prehashed::Message(_) => unimplemented!(),
+            Prehashed::Rfc6979(hasher) => hasher.update(data),
+        }
+    }
+}

--- a/src/account/public.rs
+++ b/src/account/public.rs
@@ -1,0 +1,17 @@
+//! Module implementing public key operations.
+
+use k256::elliptic_curve::sec1::ToEncodedPoint as _;
+
+/// A public key.
+pub struct PublicKey(pub k256::PublicKey);
+
+impl PublicKey {
+    /// Returns an uncompressed encoded bytes for the public key.
+    pub fn encode_uncompressed(&self) -> [u8; 65] {
+        self.0
+            .to_encoded_point(false)
+            .as_bytes()
+            .try_into()
+            .expect("unexpected uncompressed private key length")
+    }
+}

--- a/src/cmd/public_key.rs
+++ b/src/cmd/public_key.rs
@@ -19,7 +19,7 @@ pub fn run(options: Options) -> Result<()> {
                 .account
                 .private_key()?
                 .public()
-                .serialize_uncompressed()
+                .encode_uncompressed()
         )
     );
     Ok(())

--- a/src/transaction/eip1559.rs
+++ b/src/transaction/eip1559.rs
@@ -6,7 +6,7 @@ use crate::{
     transaction::accesslist::AccessList,
     transaction::rlp,
 };
-use ethnum::{AsU256 as _, U256};
+use ethnum::U256;
 use serde::Deserialize;
 
 /// An EIP-1559 Ethereum transaction.
@@ -19,10 +19,11 @@ pub struct Eip1559Transaction {
     /// The nonce for the transaction.
     #[serde(with = "serialization::u256")]
     pub nonce: U256,
-    /// The gas price in Wei for the transaction.
+    /// The maximum priority fee in Wei for the transaction.
     #[serde(rename = "maxPriorityFeePerGas")]
     #[serde(with = "serialization::u256")]
     pub max_priority_fee_per_gas: U256,
+    /// The maximum gas price in Wei for the transaction.
     #[serde(rename = "maxFeePerGas")]
     #[serde(with = "serialization::u256")]
     pub max_fee_per_gas: U256,
@@ -62,9 +63,9 @@ impl Eip1559Transaction {
 
         let tail = signature.map(|signature| {
             [
-                rlp::uint(signature.y_parity.as_u256()),
-                rlp::uint(U256::from_be_bytes(signature.r)),
-                rlp::uint(U256::from_be_bytes(signature.s)),
+                rlp::uint(signature.y_parity()),
+                rlp::uint(signature.r()),
+                rlp::uint(signature.s()),
             ]
         });
 
@@ -80,6 +81,7 @@ impl Eip1559Transaction {
 mod tests {
     use super::*;
     use crate::transaction::accesslist::StorageSlot;
+    use ethnum::AsU256 as _;
     use hex_literal::hex;
     use serde_json::json;
 

--- a/src/transaction/eip2930.rs
+++ b/src/transaction/eip2930.rs
@@ -6,7 +6,7 @@ use crate::{
     transaction::accesslist::AccessList,
     transaction::rlp,
 };
-use ethnum::{AsU256 as _, U256};
+use ethnum::U256;
 use serde::Deserialize;
 
 /// An EIP-2930 Ethereum transaction.
@@ -57,9 +57,9 @@ impl Eip2930Transaction {
 
         let tail = signature.map(|signature| {
             [
-                rlp::uint(signature.y_parity.as_u256()),
-                rlp::uint(U256::from_be_bytes(signature.r)),
-                rlp::uint(U256::from_be_bytes(signature.s)),
+                rlp::uint(signature.y_parity()),
+                rlp::uint(signature.r()),
+                rlp::uint(signature.s()),
             ]
         });
 
@@ -75,6 +75,7 @@ impl Eip2930Transaction {
 mod tests {
     use super::*;
     use crate::transaction::accesslist::StorageSlot;
+    use ethnum::AsU256 as _;
     use hex_literal::hex;
     use serde_json::json;
 

--- a/src/transaction/legacy.rs
+++ b/src/transaction/legacy.rs
@@ -5,7 +5,7 @@ use crate::{
     serialization,
     transaction::rlp,
 };
-use ethnum::{AsU256 as _, U256};
+use ethnum::U256;
 use serde::Deserialize;
 
 /// A Legacy Ethereum transaction.
@@ -48,15 +48,7 @@ impl LegacyTransaction {
         ];
 
         let tail = signature
-            .map(|signature| {
-                (
-                    self.chain_id.map_or(signature.v().as_u256(), |chain_id| {
-                        signature.v_replay_protected(chain_id)
-                    }),
-                    U256::from_be_bytes(signature.r),
-                    U256::from_be_bytes(signature.s),
-                )
-            })
+            .map(|signature| (signature.v(self.chain_id), signature.r(), signature.s()))
             .or_else(|| Some((self.chain_id?, U256::ZERO, U256::ZERO)))
             .map(|(v, r, s)| [rlp::uint(v), rlp::uint(r), rlp::uint(s)]);
 
@@ -67,6 +59,7 @@ impl LegacyTransaction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ethnum::AsU256 as _;
     use hex_literal::hex;
     use serde_json::json;
 


### PR DESCRIPTION
This PR ports `hdwallet` to use the `k256` crate - a native Rust implementation of secp256k1 elliptic curve and ECDSA signing.

The motivation for this change is that we can just use the `wasm32-wasi` Rust target without requiring a WASI C toolchain! Notice that the CI no longer requires installing the WASI SDK in order to build the WASI target.